### PR TITLE
Added test for an existing download

### DIFF
--- a/downloadSessions.ps1
+++ b/downloadSessions.ps1
@@ -20,8 +20,13 @@ foreach ($line in $lines) {
     $title = $title.replace("?",'')
     $title = $title.trim()
     $title = $title + ".mp4"
-    Write-Host "Downloading $title ..."
-    Invoke-WebRequest -Uri $url -Headers $headers -Outfile $title
+    if (Test-Path $title) {
+        Write-Host "Skipping $title (already downloaded) ..."
+    }
+    else {
+        Write-Host "Downloading $title ..."
+        Invoke-WebRequest -Uri $url -Headers $headers -Outfile $title
+    }
 }
 
 


### PR DESCRIPTION
Should the user need to stop and then resume the download process for any reason, this change will skip any already downloaded files (assuming that the working directory is the same for both runs).